### PR TITLE
Fix: NullReferenceException in NPCPatch when Robin upgrades the Farmh…

### DIFF
--- a/GreenhouseSprinklers/GreenhouseSprinklers/Patches/NPCPatch.cs
+++ b/GreenhouseSprinklers/GreenhouseSprinklers/Patches/NPCPatch.cs
@@ -28,6 +28,7 @@ internal class NPCPatch
         if (Game1.IsThereABuildingUnderConstruction())
         {
             Building b = Game1.GetBuildingUnderConstruction();
+            if (b == null) return;
             BuildingData data = b.GetData();
             if (b.upgradeName.Value != null)
             {


### PR DESCRIPTION
…ouse

Hi! Thank you for the great mod!

I was doing some testing and ran into a NullReferenceException crashing the end-of-day loop. The error points to line 31 in NPCPatch.cs: BuildingData data = b.GetData();

The cause:
When Robin is upgrading the main Farmhouse (which is tracked via Game1.player.daysUntilHouseUpgrade), the base game's Game1.GetBuildingUnderConstruction() returns null because the farmhouse isn't a standard physical Building in the map's building list.

The fix:
Adding a simple null-check right after fetching the building prevents the crash entirely without affecting the mod's logic for the Greenhouse.